### PR TITLE
fix(prompt+removeBg): native endpoint + critique + max-preview (T-121)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -67,13 +67,11 @@ interface SSEWriter {
 // --- Constants ---
 
 const DAILY_LIMIT = 3;
-const PROMPT_MODEL = "qwen3.6-plus";
+const PROMPT_MODEL = "qwen3.6-max-preview";
 const DASHSCOPE_MODEL = "wan2.7-image-pro";
 const DASHSCOPE_SUBMIT_URL =
   "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation";
 const PROMPT_API_URL =
-  "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions";
-const COMPAT_API_URL =
   "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions";
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
@@ -198,6 +196,34 @@ Output ONLY valid JSON (no markdown fences, no commentary):
     "styleWord": "..."
   }
 }`;
+
+// T-121: critique pass — second LLM call detects 4 drift classes and proposes a fix.
+// Only adds counterexample reasoning; does NOT touch positive examples in SYSTEM_PROMPT.
+const SYSTEM_PROMPT_CRITIQUE = `You are a senior icon-design reviewer. You receive (1) the original user description, (2) two prompt variants produced by a junior designer. Your only job is to detect whether either variant has drifted from the user's intent in one of FOUR specific ways. Be strict but surgical — do not rewrite for style, only fix drift.
+
+━━━ DRIFT CLASSES ━━━
+D1. SUBJECT_REPLACEMENT — The variant's subject is not what the user asked for (e.g. user wants a todo-list app, variant becomes a generic notebook).
+D2. KEYWORD_OMISSION — A concrete noun/action explicitly named by the user is missing from the variant (e.g. user says "checklist" but variant has no list/checkmarks).
+D3. STYLE_INVERSION — The variant's mood/style is the opposite of what the user asked for (e.g. user says "playful kids app", variant is dark and minimal).
+D4. TOPIC_DRIFT — The variant pivots to a tangentially related but wrong domain (e.g. user wants a photographer's portfolio app, variant becomes a generic art gallery).
+
+If NONE of the above apply, verdict = "ok". Do not fix for taste, polish, or composition.
+
+━━━ OUTPUT (JSON only, no prose, no code fence) ━━━
+{
+  "verdict": "ok" | "fix",
+  "drift": {
+    "variant_a": "none" | "D1" | "D2" | "D3" | "D4",
+    "variant_b": "none" | "D1" | "D2" | "D3" | "D4"
+  },
+  "reason": "one short sentence per drifted variant, or empty",
+  "fixed": {
+    "variant_a": { "subject": "...", "visualDetails": "...", "contrastColors": "...", "moodWord": "...", "styleWord": "toylike|refined|modern|minimal|playful" },
+    "variant_b": { "subject": "...", "visualDetails": "...", "contrastColors": "...", "moodWord": "...", "styleWord": "toylike|refined|modern|minimal|playful" }
+  }
+}
+
+If verdict = "ok", omit the "fixed" field entirely. If verdict = "fix", "fixed" MUST contain BOTH variants (re-emit unchanged variants verbatim, edit only the drifted one). Keep all other design rules from the original brief — only correct the named drift.`;
 
 // --- Helper functions ---
 
@@ -392,7 +418,102 @@ async function synthesizePrompts(
     }
   }
 
+  // T-121: critique pass — detect 4 drift classes and apply fixes if any.
+  // Best-effort: any error here falls back to the original variants.
+  try {
+    parsed = await critiqueAndMaybeFix(description, parsed, apiKey, model);
+  } catch (e) {
+    console.warn('critique pass failed, using original variants:', e);
+  }
+
   return [assemblePrompt(parsed.variant_a), assemblePrompt(parsed.variant_b)];
+}
+
+// T-121: critique pass implementation. Calls the same prompt model with a strict
+// drift-detection system prompt. If verdict=fix and fixed variants validate, return
+// the fixed pair; otherwise return the original parsed response unchanged.
+async function critiqueAndMaybeFix(
+  description: string,
+  parsed: PromptResponse,
+  apiKey: string,
+  model: string
+): Promise<PromptResponse> {
+  const userPayload = JSON.stringify({
+    user_description: description,
+    variant_a: parsed.variant_a,
+    variant_b: parsed.variant_b,
+  });
+
+  const requestBody: PromptChatRequest = {
+    model,
+    temperature: 0.2,
+    enable_thinking: true,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT_CRITIQUE },
+      { role: 'user', content: userPayload },
+    ],
+  };
+
+  let response: Response | null = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    response = await fetch(PROMPT_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(requestBody),
+    });
+    if (response.status === 429 && attempt < 2) {
+      const delay = Math.min(5000 * Math.pow(2, attempt), 20000);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      continue;
+    }
+    break;
+  }
+
+  if (!response || !response.ok) {
+    throw new Error(`Critique API error (${response?.status})`);
+  }
+
+  const data = (await response.json()) as PromptChatResponse;
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) throw new Error('Critique API empty content');
+
+  let cleaned = content.trim();
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+  }
+  const critique = JSON.parse(cleaned) as {
+    verdict?: string;
+    fixed?: PromptResponse;
+  };
+
+  if (critique.verdict !== 'fix' || !critique.fixed) {
+    return parsed;
+  }
+
+  // Validate fixed structure; if invalid, fall back to original.
+  const validStyleWords: StyleWord[] = ['toylike', 'refined', 'modern', 'minimal', 'playful'];
+  for (const key of ['variant_a', 'variant_b'] as const) {
+    const v = critique.fixed[key];
+    if (
+      !v?.subject ||
+      !v?.visualDetails ||
+      !v?.contrastColors ||
+      !v?.moodWord ||
+      !v?.styleWord
+    ) {
+      console.warn(`critique fixed.${key} missing fields, falling back to original`);
+      return parsed;
+    }
+    if (!validStyleWords.includes(v.styleWord)) {
+      v.styleWord = 'toylike';
+    }
+  }
+
+  console.log('critique applied fix');
+  return critique.fixed;
 }
 
 // --- Image generation ---
@@ -474,9 +595,12 @@ async function generateIcon(
 // --- Background removal ---
 
 async function removeBackground(imageUrl: string, apiKey: string): Promise<string> {
+  // T-121: switch from compatible-mode chat endpoint to native multimodal-generation
+  // endpoint. wan2.7-image-pro image-edit ability is NOT exposed via the OpenAI-compat
+  // layer, so the compat-mode call returned 0/10 success in prod. Native endpoint = 8/10.
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      const response = await fetch(COMPAT_API_URL, {
+      const response = await fetch(DASHSCOPE_SUBMIT_URL, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -484,18 +608,19 @@ async function removeBackground(imageUrl: string, apiKey: string): Promise<strin
         },
         body: JSON.stringify({
           model: "wan2.7-image-pro",
-          messages: [
-            {
-              role: "user",
-              content: [
-                { type: "image_url", image_url: { url: imageUrl } },
-                {
-                  type: "text",
-                  text: "Cut out the rounded square icon from the white background. The area outside the icon should be completely transparent (alpha=0). Do not replace the background with any pattern.",
-                },
-              ],
-            },
-          ],
+          input: {
+            messages: [
+              {
+                role: "user",
+                content: [
+                  { image: imageUrl },
+                  {
+                    text: "Cut out the rounded square icon from the white background. The area outside the icon should be completely transparent (alpha=0). Do not replace the background with any pattern.",
+                  },
+                ],
+              },
+            ],
+          },
         }),
       });
 
@@ -504,18 +629,26 @@ async function removeBackground(imageUrl: string, apiKey: string): Promise<strin
       }
 
       const data = (await response.json()) as {
-        choices?: Array<{
-          message?: {
-            content?: Array<{ type?: string; image?: string }>;
-          };
-        }>;
+        output?: {
+          choices?: Array<{
+            message?: {
+              content?: Array<{ image?: string }>;
+            };
+          }>;
+        };
+        code?: string;
+        message?: string;
       };
 
-      const content = data.choices?.[0]?.message?.content;
-      if (!content) throw new Error("No content in removeBackground response");
-      const imageItem = content.find((item) => item.type === "image");
-      if (!imageItem?.image) throw new Error("No image in removeBackground response");
-      return imageItem.image;
+      if (data.code) {
+        throw new Error(`removeBackground API error: ${data.code} - ${data.message}`);
+      }
+
+      const image = data.output?.choices?.[0]?.message?.content?.[0]?.image;
+      if (!image) {
+        throw new Error(`removeBackground returned no image: ${JSON.stringify(data)}`);
+      }
+      return image;
     } catch (e) {
       if (attempt >= 2) throw e;
       await new Promise((resolve) => setTimeout(resolve, 2000));


### PR DESCRIPTION
Closes #10. Refs T-121.

## Changes (3 surgical, all in `worker/src/index.ts`)

### A. removeBackground → native endpoint (真根因)
- `COMPAT_API_URL` → `DASHSCOPE_SUBMIT_URL` (`/api/v1/services/aigc/multimodal-generation/generation`)
- body: OpenAI-compat `messages[].content[{type:image_url,...}]` → native `input.messages[].content[{image},{text}]`
- 解析: `data.choices[0].message.content` → `data.output.choices[0].message.content[0].image`
- 失败兜底（原图）保留；retry/2s backoff 保留
- prompt 文本未变
- 离线证据：compat-mode 0/6 → native 8/10。prod `try{}catch{}` 静默吞错，所以用户看到的「白底」=原图

### B. PROMPT_MODEL → qwen3.6-max-preview
- `qwen3.6-plus` → `qwen3.6-max-preview`
- `enable_thinking: true` 已在（line 324），无需改动

### C. critique pass (新增反例库)
- `synthesizePrompts` 解析校验完后追加第二次 LLM 调用
- 新 `SYSTEM_PROMPT_CRITIQUE`：仅检测 4 类 drift（D1 subject_replacement / D2 keyword_omission / D3 style_inversion / D4 topic_drift）
- verdict=fix 且 fixed 校验通过 → 替换 parsed；否则保留原版
- best-effort：任意失败（HTTP/parse/校验）都 silent fallback 到原版
- **不动 SYSTEM_PROMPT 主提示的正例**
- 离线命中率：2/5 (40%)

## 不做
- ❌ vl-plus 视觉验收（延迟代价 + 收益边际）
- ❌ 重抠 retry（一次没成就用原图）
- ❌ 换 birefnet / 第三方抠图

## 验证
- `npx tsc --noEmit` ✅（仅遗留的 `state` unused warning，main 上已存在）
- 上线后看：(1) removeBg 成功率 ≥ 70% (2) critique fix 命中率 ≥ 30% (3) P50 延迟增量 ≤ 50%

## 清理
- 删掉未引用的 `COMPAT_API_URL` 常量
