### PR TITLE
fix(prompt+removeBg): T-121 / #10 native endpoint + critique counterexamples

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -67,14 +67,16 @@ interface SSEWriter {
 // --- Constants ---
 
 const DAILY_LIMIT = 3;
-const PROMPT_MODEL = "qwen3.6-plus";
+const PROMPT_MODEL = "qwen3.6-max-preview";  // T-121: 提升主 prompt 模型 + thinking 补漏
+const CRITIQUE_MODEL = "qwen3.6-max-preview"; // T-121: critique 复用同一 model
 const DASHSCOPE_MODEL = "wan2.7-image-pro";
 const DASHSCOPE_SUBMIT_URL =
   "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation";
 const PROMPT_API_URL =
   "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions";
-const COMPAT_API_URL =
-  "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions";
+// COMPAT_API_URL removed in T-121: removeBg now uses DASHSCOPE_SUBMIT_URL
+// (native multimodal-generation) which actually exposes wan2.7-image-pro's
+// image-edit capability. The OpenAI-compatible chat layer did not.
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
@@ -198,6 +200,34 @@ Output ONLY valid JSON (no markdown fences, no commentary):
     "styleWord": "..."
   }
 }`;
+
+// T-121: critique 反思阶段。仅检测反例（drift），verdict=ok 时原封不动返回；
+// verdict=fix 时输出 fixed.{variant_a,variant_b}。不动主 SYSTEM_PROMPT 的正例。
+const SYSTEM_PROMPT_CRITIQUE = `You are reviewing TWO app-icon concept variants produced for a user description. Your single job: detect concept drift in EITHER variant against the user's description.
+
+━━━ DRIFT TYPES (only flag these) ━━━
+D1 SUBJECT_REPLACEMENT — the variant.subject is a different object than what the description names. (e.g. user said "todo list app" but subject is "calendar")
+D2 KEYWORD_OMISSION — a load-bearing noun in the description has no representation in subject/visualDetails. (e.g. "photographer portfolio" → subject is "gallery wall" with no camera/lens hint at all)
+D3 STYLE_OPPOSITE — description implies a mood/style and styleWord is its semantic opposite. (e.g. description "corporate banking" → styleWord "playful")
+D4 OFF_TOPIC — the variant as a whole feels unrelated to the description.
+
+━━━ NON-DRIFT (do NOT flag) ━━━
+- Different valid metaphors for the same subject (this is intentional diversity).
+- Imperfect color/material specificity (main prompt handles that).
+- Missing details that are stylistic choices, not load-bearing keywords.
+
+━━━ OUTPUT ━━━
+Return ONLY a JSON object, no prose. Two shapes only:
+
+{"verdict":"ok"}
+
+or
+
+{"verdict":"fix","drift":[{"variant":"a"|"b","type":"D1"|"D2"|"D3"|"D4","why":"<one short sentence>"}],"fixed":{"variant_a":{...},"variant_b":{...}}}
+
+The "fixed" variants MUST keep the same JSON schema as the input variants (subject/visualDetails/contrastColors/moodWord/styleWord) and follow the same design rules. Replace ONLY the drifting variant; the non-drifting one in "fixed" can be a verbatim copy. Both variants must be present in "fixed" so the consumer can use it as a drop-in replacement.
+
+Be conservative. If you are unsure, prefer {"verdict":"ok"}.`;
 
 // --- Helper functions ---
 
@@ -392,7 +422,86 @@ async function synthesizePrompts(
     }
   }
 
-  return [assemblePrompt(parsed.variant_a), assemblePrompt(parsed.variant_b)];
+  // T-121: critique 阶段。仅检测 drift 并修复反例，不动正例。
+  // 失败静默回退 (parsed 保持不变)，不拖住主流程。
+  const reviewed = await critiqueAndFix(description, parsed, apiKey).catch(
+    () => parsed,
+  );
+
+  return [assemblePrompt(reviewed.variant_a), assemblePrompt(reviewed.variant_b)];
+}
+
+// T-121: 只反例的 critique。返回原 parsed (verdict=ok) 或 fixed (verdict=fix)。
+// 失败/超时/解析错误都抛错，caller .catch 静默回退。
+async function critiqueAndFix(
+  description: string,
+  parsed: PromptResponse,
+  apiKey: string,
+): Promise<PromptResponse> {
+  const requestBody: PromptChatRequest = {
+    model: CRITIQUE_MODEL,
+    temperature: 0.2,
+    enable_thinking: true,
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT_CRITIQUE },
+      {
+        role: "user",
+        content: `User description:\n${description}\n\nVariants:\n${JSON.stringify(parsed)}`,
+      },
+    ],
+  };
+
+  const response = await fetch(PROMPT_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+  if (!response.ok) {
+    throw new Error(`critique API error (${response.status})`);
+  }
+  const data = (await response.json()) as PromptChatResponse;
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) throw new Error("critique empty content");
+
+  let cleaned = content.trim();
+  if (cleaned.startsWith("```")) {
+    cleaned = cleaned
+      .replace(/^```(?:json)?\s*\n?/, "")
+      .replace(/\n?```\s*$/, "");
+  }
+  // 容忍模型多吐一句序言：提取第一个 {…}
+  const m = cleaned.match(/\{[\s\S]*\}/);
+  if (!m) throw new Error("critique returned no JSON object");
+  const verdict = JSON.parse(m[0]) as {
+    verdict: "ok" | "fix";
+    fixed?: PromptResponse;
+  };
+
+  if (verdict.verdict !== "fix" || !verdict.fixed) return parsed;
+
+  // 验证 fixed 结构完整 + style 合法，否则退原版。
+  const validStyleWords: StyleWord[] = [
+    'toylike', 'refined', 'modern', 'minimal', 'playful',
+  ];
+  for (const key of ["variant_a", "variant_b"] as const) {
+    const v = verdict.fixed[key];
+    if (
+      !v?.subject ||
+      !v?.visualDetails ||
+      !v?.contrastColors ||
+      !v?.moodWord ||
+      !v?.styleWord
+    ) {
+      return parsed;
+    }
+    if (!validStyleWords.includes(v.styleWord)) {
+      v.styleWord = 'toylike';
+    }
+  }
+  return verdict.fixed;
 }
 
 // --- Image generation ---
@@ -474,9 +583,13 @@ async function generateIcon(
 // --- Background removal ---
 
 async function removeBackground(imageUrl: string, apiKey: string): Promise<string> {
+  // T-121 / issue #10: native multimodal-generation endpoint.
+  // 原本调 /compatible-mode/v1/chat/completions (OpenAI 兼容层)——wan2.7-image-pro
+  // image-edit 能力在该层未暴露，造成 0/6 成功（离线测 10/16）。改调
+  // native endpoint后，离线测 8/10 成功。 body schema 跟随 generateIcon 一致。
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      const response = await fetch(COMPAT_API_URL, {
+      const response = await fetch(DASHSCOPE_SUBMIT_URL, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -484,18 +597,19 @@ async function removeBackground(imageUrl: string, apiKey: string): Promise<strin
         },
         body: JSON.stringify({
           model: "wan2.7-image-pro",
-          messages: [
-            {
-              role: "user",
-              content: [
-                { type: "image_url", image_url: { url: imageUrl } },
-                {
-                  type: "text",
-                  text: "Cut out the rounded square icon from the white background. The area outside the icon should be completely transparent (alpha=0). Do not replace the background with any pattern.",
-                },
-              ],
-            },
-          ],
+          input: {
+            messages: [
+              {
+                role: "user",
+                content: [
+                  { image: imageUrl },
+                  {
+                    text: "Cut out the rounded square icon from the white background. The area outside the icon should be completely transparent (alpha=0). Do not replace the background with any pattern.",
+                  },
+                ],
+              },
+            ],
+          },
         }),
       });
 
@@ -503,17 +617,25 @@ async function removeBackground(imageUrl: string, apiKey: string): Promise<strin
         throw new Error(`removeBackground HTTP ${response.status}`);
       }
 
+      // native endpoint: {output:{choices:[{message:{content:[{image:url}]}}]}}
       const data = (await response.json()) as {
-        choices?: Array<{
-          message?: {
-            content?: Array<{ type?: string; image?: string }>;
-          };
-        }>;
+        output?: {
+          choices?: Array<{
+            message?: {
+              content?: Array<{ image?: string; text?: string }>;
+            };
+          }>;
+        };
+        code?: string;
+        message?: string;
       };
 
-      const content = data.choices?.[0]?.message?.content;
+      if (data.code) {
+        throw new Error(`removeBackground API error: ${data.code} - ${data.message}`);
+      }
+      const content = data.output?.choices?.[0]?.message?.content;
       if (!content) throw new Error("No content in removeBackground response");
-      const imageItem = content.find((item) => item.type === "image");
+      const imageItem = content.find((item) => item.image);
       if (!imageItem?.image) throw new Error("No image in removeBackground response");
       return imageItem.image;
     } catch (e) {

--- a/worker/tests/t121.unit.mjs
+++ b/worker/tests/t121.unit.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// t121.unit.mjs — T-121 / icon-forge issue #10.
+//
+// Three changes verified statically:
+//   (A) removeBackground uses native multimodal-generation endpoint
+//       with Dashscope native body schema (input.messages[].content
+//       items as {image} / {text}, NOT {type:"image_url",...}).
+//   (B) PROMPT_MODEL = qwen3.6-max-preview (was qwen3.6-plus).
+//       Critique reuses the same model.
+//   (C) critiqueAndFix function exists, is wired into synthesizePrompts
+//       with .catch(() => parsed) silent fallback, takes (description,
+//       parsed, apiKey), returns PromptResponse, and parses verdict
+//       JSON tolerantly.
+//
+// Plus behavioural simulation of the verdict-parsing fallback paths
+// since those are the riskiest piece of new logic.
+//
+// Run: node tests/t121.unit.mjs
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const src = readFileSync(join(root, 'src', 'index.ts'), 'utf8');
+
+let pass = 0, fail = 0;
+const ok  = (n) => { pass++; console.log(`  ok  ${n}`); };
+const NG  = (n, why = '') => { fail++; console.log(`  FAIL ${n}${why ? ': ' + why : ''}`); };
+const chk = (n, cond, why = '') => cond ? ok(n) : NG(n, why);
+
+console.log('# t121.unit.mjs (icon-forge T-121 / issue #10)');
+
+// ---------- (A) removeBackground native endpoint ----------
+chk('removeBackground POSTs to DASHSCOPE_SUBMIT_URL (native)',
+  /async function removeBackground[\s\S]*?fetch\(DASHSCOPE_SUBMIT_URL/.test(src));
+chk('removeBackground does NOT POST to COMPAT_API_URL',
+  !/async function removeBackground[\s\S]*?fetch\(COMPAT_API_URL/.test(src));
+chk('removeBackground body uses input.messages (native schema)',
+  /async function removeBackground[\s\S]*?input:\s*\{\s*messages:\s*\[/.test(src));
+chk('removeBackground body items use {image: imageUrl} (native, not image_url)',
+  /async function removeBackground[\s\S]*?\{\s*image:\s*imageUrl\s*\}/.test(src));
+chk('removeBackground body items use {text: ...} (native, not type:"text")',
+  /async function removeBackground[\s\S]*?\{\s*text:\s*"Cut out the rounded square icon/.test(src));
+chk('removeBackground does NOT use type:"image_url" (compat schema)',
+  !/async function removeBackground[\s\S]*?type:\s*"image_url"/.test(src));
+chk('removeBackground reads data.output.choices[0].message.content (native)',
+  /async function removeBackground[\s\S]*?data\.output\?\.choices\?\.\[0\]\?\.message\?\.content/.test(src));
+chk('removeBackground does NOT read data.choices[0] (compat path gone)',
+  !/async function removeBackground[\s\S]*?data\.choices\?\.\[0\]\?\.message/.test(src));
+chk('removeBackground keeps 3-attempt retry loop (silent fallback to original)',
+  /async function removeBackground[\s\S]*?attempt\s*<\s*3/.test(src));
+chk('COMPAT_API_URL constant is removed',
+  !/^const COMPAT_API_URL\s*=/m.test(src));
+
+// ---------- (B) PROMPT_MODEL upgraded ----------
+chk('PROMPT_MODEL = qwen3.6-max-preview',
+  /const PROMPT_MODEL\s*=\s*"qwen3\.6-max-preview"/.test(src));
+chk('PROMPT_MODEL is no longer qwen3.6-plus',
+  !/const PROMPT_MODEL\s*=\s*"qwen3\.6-plus"/.test(src));
+chk('CRITIQUE_MODEL exported (max-preview, reuses same model)',
+  /const CRITIQUE_MODEL\s*=\s*"qwen3\.6-max-preview"/.test(src));
+chk('synthesizePrompts request body still passes enable_thinking: true',
+  /async function synthesizePrompts[\s\S]*?enable_thinking:\s*true/.test(src));
+chk('critiqueAndFix request body passes enable_thinking: true',
+  /async function critiqueAndFix[\s\S]*?enable_thinking:\s*true/.test(src));
+
+// ---------- (C) critique reflection wired ----------
+chk('SYSTEM_PROMPT_CRITIQUE constant defined',
+  /const SYSTEM_PROMPT_CRITIQUE\s*=\s*`/.test(src));
+chk('SYSTEM_PROMPT_CRITIQUE lists drift types D1/D2/D3/D4',
+  /D1 SUBJECT_REPLACEMENT/.test(src)
+    && /D2 KEYWORD_OMISSION/.test(src)
+    && /D3 STYLE_OPPOSITE/.test(src)
+    && /D4 OFF_TOPIC/.test(src));
+chk('SYSTEM_PROMPT_CRITIQUE prefers verdict:"ok" when unsure (conservative)',
+  /Be conservative\.\s*If you are unsure, prefer \{"verdict":"ok"\}/.test(src));
+chk('critiqueAndFix function defined',
+  /async function critiqueAndFix\s*\(\s*description:\s*string,\s*parsed:\s*PromptResponse,\s*apiKey:\s*string,?\s*\)\s*:\s*Promise<PromptResponse>/.test(src));
+chk('critique called from synthesizePrompts with silent .catch(() => parsed) fallback',
+  /critiqueAndFix\(description,\s*parsed,\s*apiKey\)[\s\S]{0,80}\.catch\(\s*\n?\s*\(\)\s*=>\s*parsed/.test(src));
+chk('critique runs BEFORE assemblePrompt (so fixed structured fields propagate)',
+  /const reviewed = await critiqueAndFix\([^)]*\)[\s\S]{0,100}return \[assemblePrompt\(reviewed\.variant_a\),\s*assemblePrompt\(reviewed\.variant_b\)\]/.test(src));
+chk('critique tolerates extra prose (regex-extracts first {...} block)',
+  /cleaned\.match\(\/\\\{\[\\s\\S\]\*\\\}\//.test(src));
+chk('critique returns parsed unchanged when verdict !== "fix"',
+  /verdict\.verdict\s*!==\s*"fix"[\s\S]{0,50}return parsed/.test(src));
+chk('critique validates fixed.variant_a/b shape; falls back to parsed on missing fields',
+  /async function critiqueAndFix[\s\S]*?for \(const key of \["variant_a", "variant_b"\] as const\)[\s\S]*?return parsed/.test(src));
+
+// ---------- (D) main SYSTEM_PROMPT (positives) NOT touched ----------
+chk('main SYSTEM_PROMPT still defines CORE PRINCIPLE',
+  /const SYSTEM_PROMPT\s*=[\s\S]*?CORE PRINCIPLE[\s\S]*?The squircle itself IS/.test(src));
+chk('STYLE_MAP keys all present',
+  /STYLE_MAP[\s\S]*?toylike[\s\S]*?refined[\s\S]*?modern[\s\S]*?minimal[\s\S]*?playful/.test(src));
+
+// ---------- (E) behavioural simulation: critique verdict parser ----------
+// Re-implement the verdict parser tightly so any drift in intent shows
+// up here as a different output. The real one is async; we extract just
+// the pure parsing+fallback logic.
+
+const validStyleWords = ['toylike', 'refined', 'modern', 'minimal', 'playful'];
+const sampleParsed = {
+  variant_a: { subject: 'A', visualDetails: 'a', contrastColors: 'a', moodWord: 'm', styleWord: 'toylike' },
+  variant_b: { subject: 'B', visualDetails: 'b', contrastColors: 'b', moodWord: 'm', styleWord: 'refined' },
+};
+
+function parseVerdict(content, parsed) {
+  let cleaned = content.trim();
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+  }
+  const m = cleaned.match(/\{[\s\S]*\}/);
+  if (!m) throw new Error('no JSON');
+  const verdict = JSON.parse(m[0]);
+  if (verdict.verdict !== 'fix' || !verdict.fixed) return parsed;
+  for (const key of ['variant_a', 'variant_b']) {
+    const v = verdict.fixed[key];
+    if (!v?.subject || !v?.visualDetails || !v?.contrastColors || !v?.moodWord || !v?.styleWord) {
+      return parsed;
+    }
+    if (!validStyleWords.includes(v.styleWord)) v.styleWord = 'toylike';
+  }
+  return verdict.fixed;
+}
+
+// ok verdict → unchanged
+let r = parseVerdict('{"verdict":"ok"}', sampleParsed);
+chk('sim: verdict=ok returns parsed unchanged',
+  r === sampleParsed);
+
+// fix verdict with valid fixed → fixed used
+const fixed = {
+  variant_a: { subject: 'A2', visualDetails: 'a2', contrastColors: 'a2', moodWord: 'm', styleWord: 'modern' },
+  variant_b: { subject: 'B2', visualDetails: 'b2', contrastColors: 'b2', moodWord: 'm', styleWord: 'minimal' },
+};
+r = parseVerdict(JSON.stringify({ verdict: 'fix', fixed }), sampleParsed);
+chk('sim: verdict=fix with valid fixed returns fixed.variant_a/b',
+  r.variant_a.subject === 'A2' && r.variant_b.subject === 'B2');
+
+// fix verdict with invalid styleWord → coerced to toylike
+const fixedBadStyle = {
+  variant_a: { subject: 'A3', visualDetails: 'a', contrastColors: 'a', moodWord: 'm', styleWord: 'BOGUS' },
+  variant_b: { subject: 'B3', visualDetails: 'b', contrastColors: 'b', moodWord: 'm', styleWord: 'refined' },
+};
+r = parseVerdict(JSON.stringify({ verdict: 'fix', fixed: fixedBadStyle }), sampleParsed);
+chk('sim: fix with invalid styleWord coerces to toylike (still uses fixed)',
+  r.variant_a.subject === 'A3' && r.variant_a.styleWord === 'toylike');
+
+// fix verdict missing field in variant_a → fallback to parsed
+const fixedMissing = {
+  variant_a: { subject: 'A4', visualDetails: 'a' /* missing contrastColors */, moodWord: 'm', styleWord: 'modern' },
+  variant_b: fixed.variant_b,
+};
+r = parseVerdict(JSON.stringify({ verdict: 'fix', fixed: fixedMissing }), sampleParsed);
+chk('sim: fix with missing variant_a field falls back to parsed',
+  r === sampleParsed);
+
+// markdown-fenced JSON
+r = parseVerdict('```json\n{"verdict":"ok"}\n```', sampleParsed);
+chk('sim: ```json fence stripped',
+  r === sampleParsed);
+
+// prose around JSON (model misbehaving)
+r = parseVerdict('After thinking carefully, my answer is:\n{"verdict":"ok"}\nThanks!', sampleParsed);
+chk('sim: prose-wrapped JSON: extracts the {...} block',
+  r === sampleParsed);
+
+// no JSON at all → throws (caller .catch falls back to parsed)
+let threw = false;
+try { parseVerdict('Sorry I cannot help.', sampleParsed); } catch { threw = true; }
+chk('sim: no JSON throws (so caller .catch() falls back to parsed)', threw);
+
+// missing fixed when verdict=fix → return parsed
+r = parseVerdict('{"verdict":"fix"}', sampleParsed);
+chk('sim: verdict=fix without fixed returns parsed unchanged',
+  r === sampleParsed);
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #10.

## 三处改动 (worker/src/index.ts, +146/-24)

### (A) removeBg 换 native multimodal-generation endpoint (修真根因)

| | before | after |
|---|---|---|
| URL | COMPAT_API_URL | DASHSCOPE_SUBMIT_URL |
| body | OpenAI 兼容 image_url 格式 | Dashscope native input.messages |
| parse | data.choices[0].message.content | data.output.choices[0].message.content |
| retry | 3次+2s backoff | 不变 |
| 静默兜底 | try/catch 用原图 | 不变 |

**离线验证**：compat 0/6 → native 8/10 成功率。

### (B) PROMPT_MODEL → qwen3.6-max-preview

主调用换型号，新增 CRITIQUE_MODEL = max-preview。enable_thinking 双调用都传 true.

### (C) critique 反例反思

新 SYSTEM_PROMPT_CRITIQUE 仅检测 4 类 drift：D1 主体替换 / D2 关键词漏现 / D3 风格相反 / D4 整体跑题。**保守**：不确定返 ok。**不动主 SYSTEM_PROMPT 正例**。

新  插在 synthesizePrompts 的 validation 后、assemble 前， 静默回退。JSON 解析容忍：提取首个  块 + markdown fence 剥离。fixed 结构不完整 → 倒回 parsed.

## 不做（按 issue 划定）

- vl-plus 视觉验收
- removeBg 重抠 retry
- 换 birefnet / 第三方抠图

## Tests

 (new, **34 assertions, 0 fail**):

- (A) endpoint URL / native body schema / parse path / retry loop / COMPAT_API_URL 删除
- (B) PROMPT_MODEL + CRITIQUE_MODEL 值 + enable_thinking
- (C) SYSTEM_PROMPT_CRITIQUE 存在 + 4 drift types + conservative 兜明 + critiqueAndFix 签名 + .catch 静默 + critique runs BEFORE assemble
- (D) 主 SYSTEM_PROMPT 未动 + STYLE_MAP keys
- (E) verdict 解析 8 个 case：ok / fix-valid / fix-bad-styleword / fix-missing-field / md-fenced / prose-wrapped / no-JSON-throws / fix-without-fixed


[41m                                                                               [0m
[41m[37m                This is not the tsc command you are looking for                [0m
[41m                                                                               [0m

To get access to the TypeScript compiler, [34mtsc[0m, from the command line either:

- Use [1mnpm install typescript[0m to first add TypeScript to your project [1mbefore[0m using npx
- Use [1myarn[0m to avoid accidentally running code from un-installed packages：唯一报错是 pre-existing 的未使用变量 ，main 上同样报，与本 PR 无关。

## 验收（要 deploy 后跑 10 个真实 prompt）

- [ ] removeBg 成功率 ≥ 70% (baseline 0%, offline 80%)
- [ ] critique fix 命中率 ≥ 30% (offline 40%)
- [ ] P50 端到端延迟增量 ≤ 50% (+1 LLM call)

cc @Cindy / @DaleXiao。