### PR TITLE
feat(SPEC-179 / T-282): icon-forge worker timeout + thinking + frontend 403 根治

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -406,6 +406,23 @@ export default function App() {
         return
       }
 
+      // SPEC-179 B-4: explicit 403 handler. Previously fell through to
+      // the generic !res.ok branch and surfaced the worker's turnstile
+      // error verbatim ("人机验证未通过…") — confusing in `?test`
+      // mode where the worker bypasses turnstile entirely (any 403 in
+      // that mode is therefore a real backend / origin problem, not a
+      // captcha problem).
+      if (res.status === 403) {
+        const data: ErrorResponse = await res.json().catch(() => ({} as ErrorResponse))
+        const msg = TEST_PARAM
+          ? '测试模式请求被拒，请检查控制台。'
+          : (data.message || '人机验证未通过，请刷新重试')
+        setError(msg)
+        setPhase('error')
+        setLoading(false)
+        return
+      }
+
       if (!res.ok) {
         const data: ErrorResponse = await res.json()
         setError(data.message || '生成失败，请重试')

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -86,7 +86,17 @@ const CORS_HEADERS: Record<string, string> = {
 };
 
 const MAX_QUEUE_SIZE = 10;
-const TASK_TIMEOUT_MS = 120_000;
+// SPEC-179 B-3: bump from 120s → 180s. prompt 60s + 4 × image 10s = 100s
+// hit the old ceiling under any prompt slowdown. The per-LLM-fetch
+// AbortController (B-2) caps individual stalls, so the task envelope
+// only needs to cover successful end-to-end work.
+const TASK_TIMEOUT_MS = 180_000;
+// SPEC-179 B-1/B-2: per-LLM-fetch caps. enable_thinking can blow up
+// reasoning_tokens without max_tokens; without an AbortController the
+// underlying fetch sits idle until the task budget aborts the whole
+// request. Cap both.
+const LLM_CHAT_MAX_TOKENS = 2400;
+const LLM_CHAT_TIMEOUT_MS = 60_000;
 
 // Origin allowlist — only these front-ends may call the mutating endpoints.
 const ALLOWED_ORIGINS = new Set<string>([
@@ -355,6 +365,10 @@ async function synthesizePrompts(
     model,
     temperature: 0.8,
     enable_thinking: true,
+    // SPEC-179 B-1: cap reasoning explosion. enable_thinking without
+    // max_tokens lets the model burn 1k+ reasoning_tokens, pushing the
+    // chat fetch past 90s. Same cap as ukiyo-e / gepa-server.
+    max_tokens: LLM_CHAT_MAX_TOKENS,
     messages: [
       { role: "system", content: SYSTEM_PROMPT },
       { role: "user", content: description },
@@ -364,14 +378,33 @@ async function synthesizePrompts(
   // Retry loop for prompt API (handles 429 rate limit)
   let response: Response | null = null;
   for (let attempt = 0; attempt < 3; attempt++) {
-    response = await fetch(`${gatewayUrl}${CHAT_PATH}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(requestBody),
-    });
+    // SPEC-179 B-2: per-attempt AbortController so a stuck fetch fails
+    // fast (60s) and either retries below or bubbles up to caller; the
+    // previous code only aborted at the task-envelope deadline.
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), LLM_CHAT_TIMEOUT_MS);
+    try {
+      response = await fetch(`${gatewayUrl}${CHAT_PATH}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(requestBody),
+        signal: ac.signal,
+      });
+    } catch (err) {
+      const isAbort = (err as Error | undefined)?.name === "AbortError";
+      if (isAbort && attempt < 2) {
+        clearTimeout(timer);
+        continue; // retry once on timeout
+      }
+      clearTimeout(timer);
+      throw isAbort
+        ? new Error(`Prompt API timeout after ${LLM_CHAT_TIMEOUT_MS}ms`)
+        : (err as Error);
+    }
+    clearTimeout(timer);
 
     if (response.status === 429 && attempt < 2) {
       const delay = Math.min(5000 * Math.pow(2, attempt), 20000);
@@ -446,6 +479,9 @@ async function critiqueAndFix(
     model: CRITIQUE_MODEL,
     temperature: 0.2,
     enable_thinking: true,
+    // SPEC-179 B-1: same reasoning cap as synthesizePrompts; critique
+    // returns small JSON, 2400 tokens is plenty.
+    max_tokens: LLM_CHAT_MAX_TOKENS,
     messages: [
       { role: "system", content: SYSTEM_PROMPT_CRITIQUE },
       {
@@ -455,14 +491,30 @@ async function critiqueAndFix(
     ],
   };
 
-  const response = await fetch(`${gatewayUrl}${CHAT_PATH}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify(requestBody),
-  });
+  // SPEC-179 B-2: AbortController so a stuck critique fetch doesn't
+  // eat the parent task envelope. Caller .catch() falls back to the
+  // un-critiqued parsed prompts on any error, including timeout.
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), LLM_CHAT_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`${gatewayUrl}${CHAT_PATH}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(requestBody),
+      signal: ac.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    if ((err as Error | undefined)?.name === "AbortError") {
+      throw new Error(`critique API timeout after ${LLM_CHAT_TIMEOUT_MS}ms`);
+    }
+    throw err;
+  }
+  clearTimeout(timer);
   if (!response.ok) {
     // SPEC-160: 401 → 配置问题，不重试
     if (response.status === 401) {

--- a/worker/tests/spec-179.unit.mjs
+++ b/worker/tests/spec-179.unit.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// spec-179.unit.mjs — SPEC-179 / T-282.
+//
+// Static-grep coverage for the four icon-forge worker / front-end fixes:
+//   B-1  synthesizePrompts + critiqueAndFix request body declares
+//        max_tokens: LLM_CHAT_MAX_TOKENS (cap reasoning explosion).
+//   B-2  Both chat fetches use an AbortController + LLM_CHAT_TIMEOUT_MS.
+//   B-3  TASK_TIMEOUT_MS bumped 120_000 → 180_000.
+//   B-4  src/App.tsx has an explicit res.status === 403 branch that
+//        rewrites the message in `?test` mode.
+//
+// Plus a regression guard: no enable_thinking:true chat call remains
+// without a max_tokens cap.
+//
+// Run: node tests/spec-179.unit.mjs
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const repoRoot = join(root, '..');
+const workerSrc = readFileSync(join(root, 'src', 'index.ts'), 'utf8');
+const appSrc = readFileSync(join(repoRoot, 'src', 'App.tsx'), 'utf8');
+
+let pass = 0, fail = 0;
+const ok = (n) => { pass++; console.log(`  ok  ${n}`); };
+const NG = (n, why = '') => { fail++; console.log(`  FAIL ${n}${why ? ': ' + why : ''}`); };
+const chk = (n, cond, why = '') => cond ? ok(n) : NG(n, why);
+
+console.log('# spec-179.unit.mjs (SPEC-179 / T-282)');
+
+// ─── B-1: max_tokens caps ────────────────────────────────────────────
+console.log('\n## B-1: max_tokens caps');
+chk(
+  'worker declares LLM_CHAT_MAX_TOKENS constant',
+  /const\s+LLM_CHAT_MAX_TOKENS\s*=\s*2400/.test(workerSrc),
+);
+// synthesizePrompts requestBody has max_tokens
+const synthBlock = workerSrc.match(
+  /function\s+synthesizePrompts[\s\S]*?const\s+requestBody:[\s\S]*?\};/,
+);
+chk('found synthesizePrompts requestBody block', synthBlock !== null);
+chk(
+  'synthesizePrompts requestBody sets max_tokens: LLM_CHAT_MAX_TOKENS',
+  synthBlock !== null && /max_tokens:\s*LLM_CHAT_MAX_TOKENS/.test(synthBlock[0]),
+);
+// critiqueAndFix requestBody has max_tokens
+const critiqueBlock = workerSrc.match(
+  /function\s+critiqueAndFix[\s\S]*?const\s+requestBody:[\s\S]*?\};/,
+);
+chk('found critiqueAndFix requestBody block', critiqueBlock !== null);
+chk(
+  'critiqueAndFix requestBody sets max_tokens: LLM_CHAT_MAX_TOKENS',
+  critiqueBlock !== null && /max_tokens:\s*LLM_CHAT_MAX_TOKENS/.test(critiqueBlock[0]),
+);
+
+// Regression guard: no `enable_thinking: true` chat body without max_tokens.
+// We approximate by walking every chat requestBody literal.
+const enableThinkingHits = (workerSrc.match(/enable_thinking:\s*true/g) || []).length;
+const enableThinkingWithCap = (
+  workerSrc.match(/enable_thinking:\s*true[\s\S]{0,400}?max_tokens:\s*LLM_CHAT_MAX_TOKENS/g) || []
+).length;
+chk(
+  `every enable_thinking:true also has max_tokens cap (${enableThinkingWithCap}/${enableThinkingHits})`,
+  enableThinkingHits > 0 && enableThinkingHits === enableThinkingWithCap,
+);
+
+// ─── B-2: AbortController on chat fetches ────────────────────────────
+console.log('\n## B-2: AbortController on chat fetches');
+chk(
+  'worker declares LLM_CHAT_TIMEOUT_MS = 60_000',
+  /const\s+LLM_CHAT_TIMEOUT_MS\s*=\s*60_000/.test(workerSrc),
+);
+chk(
+  'synthesizePrompts wraps chat fetch with AbortController',
+  /function\s+synthesizePrompts[\s\S]*?new\s+AbortController\(\)[\s\S]*?signal:\s*ac\.signal[\s\S]*?CHAT_PATH/.test(workerSrc)
+    || /function\s+synthesizePrompts[\s\S]*?new\s+AbortController\(\)[\s\S]*?CHAT_PATH[\s\S]*?signal:\s*ac\.signal/.test(workerSrc),
+);
+chk(
+  'synthesizePrompts schedules ac.abort() with LLM_CHAT_TIMEOUT_MS',
+  /function\s+synthesizePrompts[\s\S]*?setTimeout\(\s*\(\)\s*=>\s*ac\.abort\(\)\s*,\s*LLM_CHAT_TIMEOUT_MS\s*\)/.test(workerSrc),
+);
+chk(
+  'critiqueAndFix wraps chat fetch with AbortController',
+  /function\s+critiqueAndFix[\s\S]*?new\s+AbortController\(\)[\s\S]*?signal:\s*ac\.signal/.test(workerSrc),
+);
+chk(
+  'critiqueAndFix schedules ac.abort() with LLM_CHAT_TIMEOUT_MS',
+  /function\s+critiqueAndFix[\s\S]*?setTimeout\(\s*\(\)\s*=>\s*ac\.abort\(\)\s*,\s*LLM_CHAT_TIMEOUT_MS\s*\)/.test(workerSrc),
+);
+chk(
+  'synthesizePrompts treats AbortError as retryable / surfaces timeout',
+  /AbortError[\s\S]{0,400}?continue/.test(workerSrc)
+    && /Prompt API timeout after \$\{LLM_CHAT_TIMEOUT_MS\}ms/.test(workerSrc),
+);
+chk(
+  'critiqueAndFix surfaces AbortError as critique API timeout',
+  /critique API timeout after \$\{LLM_CHAT_TIMEOUT_MS\}ms/.test(workerSrc),
+);
+
+// ─── B-3: TASK_TIMEOUT_MS bump ───────────────────────────────────────
+console.log('\n## B-3: TASK_TIMEOUT_MS bump');
+chk(
+  'TASK_TIMEOUT_MS = 180_000',
+  /const\s+TASK_TIMEOUT_MS\s*=\s*180_000/.test(workerSrc),
+);
+chk(
+  'old 120_000 envelope is gone (regression guard)',
+  !/const\s+TASK_TIMEOUT_MS\s*=\s*120_000/.test(workerSrc),
+);
+
+// ─── B-4: front-end 403 branch ───────────────────────────────────────
+console.log('\n## B-4: front-end 403 branch');
+chk(
+  'App.tsx has explicit res.status === 403 handler',
+  /if\s*\(\s*res\.status\s*===\s*403\s*\)/.test(appSrc),
+);
+chk(
+  'App.tsx 403 handler rewrites message in TEST_PARAM mode',
+  /res\.status\s*===\s*403[\s\S]{0,500}?TEST_PARAM\s*\?[\s\S]{0,200}?'\u6d4b\u8bd5\u6a21\u5f0f/.test(appSrc),
+);
+chk(
+  'App.tsx 403 handler still falls back to data.message when not in test',
+  /res\.status\s*===\s*403[\s\S]{0,500}?data\.message/.test(appSrc),
+);
+chk(
+  '403 branch sits BEFORE the generic !res.ok fallback',
+  appSrc.indexOf('res.status === 403') < appSrc.indexOf('if (!res.ok)'),
+);
+
+// ─── summary ─────────────────────────────────────────────────────────
+console.log(`\n# spec-179.unit.mjs: ${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Spec / Task
- spec: SPEC-179 (https://agents.weweekly.online/spec/SPEC-179)
- task: T-282 (https://agents.weweekly.online/task/T-282) owner=rei

## TL;DR
Dale 实测 icon.weweekly.online 反复 fail 不是 qwen 不稳，是 worker 自己的 timeout 设计 bug + 前端 403 文案串错。本 PR 合修 4 项。

## 改动

### B-1 [P0] max_tokens 上限
`worker/src/index.ts`：`synthesizePrompts` 和 `critiqueAndFix` requestBody 加 `max_tokens: LLM_CHAT_MAX_TOKENS=2400`。`enable_thinking:true` 不限 max_tokens 会让 reasoning_tokens 失控到 90s+。镜像 ukiyo-e PR #15 / gepa-server PR #53。

### B-2 [P0] AbortController + 60s timeout
两处 chat fetch 加 `new AbortController()` + `setTimeout(() => ac.abort(), LLM_CHAT_TIMEOUT_MS=60_000)`。
- `synthesizePrompts`：AbortError 且 attempt<2 自动重试，否则抛明确 timeout
- `critiqueAndFix`：AbortError 抛 timeout，外层 `.catch(() => parsed)` 回退原 prompts

### B-3 [P1] TASK_TIMEOUT_MS 120s → 180s
prompt 60s + 4×image 10s = 100s 距旧上限太近，prompt 慢 5s 即崩。B-2 已限单次 fetch，task envelope 只需覆盖正常工作量。

### B-4 [P2] 前端 403 文案
`src/App.tsx` 加 explicit `res.status === 403` 分支。原代码 403 落到 generic `!res.ok`，把 worker 的「人机验证未通过」直接塞回前端。`?test` 模式下 worker 早已 bypass turnstile，任何 403 都是后端/origin 问题，不该再说 captcha。`?test` 模式下覆盖为「测试模式请求被拒，请检查控制台」。

## 验收

- ✅ `worker/tests/spec-179.unit.mjs` 19/19 pass，含 regression guard「每个 enable_thinking:true 必带 max_tokens」
- ✅ 既存 t121.unit.mjs fail 3 项 pre-existing（SPEC-160 gateway cutover 后留下，stash 验证）
- ✅ worker tsc 唯一警告 pre-existing TS6133 未使用 `state`
- Cindy deploy 后 Dale 实测：
  - `?test` 模式连点 5 次成功率 100%
  - 正常模式（turnstile 通）成功率 ≥95%
  - api-llm D1 service=icon-forge 不再有 status=0 latency=120000 行
  - `?test` URL 不再出现「人机验证未通过」字面

## 回滚
worker `wrangler rollback e2a585b`；前端 pages.dev 上一版。无 D1 改动。

Closes T-282.