### PR TITLE
feat(icon-forge): upgrade prompt+critique LLM to qwen3.7-max

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -70,8 +70,8 @@ interface SSEWriter {
 // --- Constants ---
 
 const DAILY_LIMIT = 3;
-const PROMPT_MODEL = "qwen3.6-max-preview";  // T-121: 提升主 prompt 模型 + thinking 补漏
-const CRITIQUE_MODEL = "qwen3.6-max-preview"; // T-121: critique 复用同一 model
+const PROMPT_MODEL = "qwen3.7-max";  // SPEC-235 followup: 3.7 比 3.6-max-preview 快 2.6x 同质量 (offline bench 8/8 pass, 28s vs 73s avg)
+const CRITIQUE_MODEL = "qwen3.7-max"; // critique 同 model
 const DASHSCOPE_MODEL = "wan2.7-image-pro";
 // SPEC-160: endpoints 全部走 api-llm.openclawd.co gateway。
 // Gateway 内部透传到 dashscope，上游响应 schema 不变；icon-forge 解析逻辑 0 修改。

--- a/worker/tests/t121.unit.mjs
+++ b/worker/tests/t121.unit.mjs
@@ -55,12 +55,14 @@ chk('COMPAT_API_URL constant is removed',
   !/^const COMPAT_API_URL\s*=/m.test(src));
 
 // ---------- (B) PROMPT_MODEL upgraded ----------
-chk('PROMPT_MODEL = qwen3.6-max-preview',
-  /const PROMPT_MODEL\s*=\s*"qwen3\.6-max-preview"/.test(src));
+chk('PROMPT_MODEL = qwen3.7-max',
+  /const PROMPT_MODEL\s*=\s*"qwen3\.7-max"/.test(src));
 chk('PROMPT_MODEL is no longer qwen3.6-plus',
   !/const PROMPT_MODEL\s*=\s*"qwen3\.6-plus"/.test(src));
-chk('CRITIQUE_MODEL exported (max-preview, reuses same model)',
-  /const CRITIQUE_MODEL\s*=\s*"qwen3\.6-max-preview"/.test(src));
+chk('PROMPT_MODEL is no longer qwen3.6-max-preview (upgraded to 3.7)',
+  !/const PROMPT_MODEL\s*=\s*"qwen3\.6-max-preview"/.test(src));
+chk('CRITIQUE_MODEL exported (qwen3.7-max, reuses same model)',
+  /const CRITIQUE_MODEL\s*=\s*"qwen3\.7-max"/.test(src));
 chk('synthesizePrompts request body still passes enable_thinking: true',
   /async function synthesizePrompts[\s\S]*?enable_thinking:\s*true/.test(src));
 chk('critiqueAndFix request body passes enable_thinking: true',


### PR DESCRIPTION
## Why
qwen3.7-max 全面胜出 qwen3.6-max-preview(offline 8/8 bench):
- **2.6x 快**:28s vs 73s avg
- **同 schema 完整度**:8/8 通过
- **更具象的 metaphor**:study cards / rotary timer / light meter(vs felt tray / focus dial)
- 真出图 4 张视觉验证通过(Dale: 「好很多」)

## What
- worker/src/index.ts: PROMPT_MODEL / CRITIQUE_MODEL: qwen3.6-max-preview → qwen3.7-max
- worker/tests/t121.unit.mjs: 更新 model assertions

生图模型 wan2.7-image-pro 不变。

## Pre-existing test failures (untouched)
3 个 fail 是 SPEC-160 命名重构遗留(removeBackground / critiqueAndFix 函数名正则),跟本 PR 无关。

## Deploy
manual wrangler deploy by cindy (CF auto-build not configured for icon-forge — same as aso)