### PR TITLE
feat(SPEC-285 迁移#1 / T-485): icon-forge 接入 model 路由中台

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -381,6 +381,8 @@ async function synthesizePrompts(
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
+        // SPEC-285 迁移#1：标注 usecase，网关自动发现 + 允许 dashboard 热切（不设 override 时仍用 body.model）
+        "x-llm-usecase": "prompt-gen",
       },
       body: JSON.stringify(requestBody),
     });
@@ -472,6 +474,8 @@ async function critiqueAndFix(
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
+      // SPEC-285 迁移#1：critique 场景 usecase
+      "x-llm-usecase": "critique",
     },
     body: JSON.stringify(requestBody),
   });
@@ -540,6 +544,8 @@ async function generateIcon(
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
+        // SPEC-285 迁移#1：icon 生成场景 usecase
+        "x-llm-usecase": "icon-image",
       },
       body: JSON.stringify({
         model: DASHSCOPE_MODEL,
@@ -623,6 +629,8 @@ async function removeBackground(imageUrl: string, apiKey: string, gatewayUrl: st
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
+          // SPEC-285 迁移#1：抠图去背景场景 usecase
+          "x-llm-usecase": "remove-bg",
         },
         body: JSON.stringify({
           model: "wan2.7-image-pro",


### PR DESCRIPTION
## SPEC-285 业务迁移#1 — icon-forge

按 spec 迁移序列首个（风险最低）。给 4 个 LLM 调用点标注 `usecase`（`x-llm-usecase` header），接入路由中台。

### 调用点 → usecase
| 调用点 | 端点 | usecase | body.model（observed） |
|---|---|---|---|
| synthesizePrompts | chat | `prompt-synth` | qwen3.7-max |
| critiqueAndFix | chat | `critique-fix` | qwen3.7-max |
| generateIcon | image | `icon-generate` | wan2.7-image-pro |
| removeBackground | image | `bg-remove` | wan2.7-image-pro |

### 关键
- **body.model 不变** → 网关自动发现记为 observed 默认；**不设 override 时行为逐字节不变**
- 换 model 自此永久零代码（dashboard 设 override ≤60s 热切）
- 纯 header 标注，零逻辑改动（diff 8 行 = 4 header + 4 注释）

### 验收
- root `npx tsc --noEmit`（CI gate）green
- worker t121 单测 32 pass / 3 pre-existing fail（clean main 同样 3 fail，stale string-match，与本改无关）
- 迁移 DoD（合并部署后）：跑真实流量 → 4 usecase 自动出现在 dashboard icon-forge 分组、observed=当前 model；设 override ≤60s 热切；清 override 回默认

spec: SPEC-285 | task: T-485